### PR TITLE
Reorder Dockerfile to reduce time of `apt-get update`

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -15,13 +15,13 @@ RUN cd /usr/local/bin && \
     ln -s /usr/bin/python3 python && \
     pip3 install --upgrade pip
 
-# cleanse
-RUN apt-get clean && \
-	rm -rf /var/lib/apt/lists/*
-
 # install konlpy
 RUN pip3 install jpype1-py3 konlpy
 RUN curl -s https://raw.githubusercontent.com/konlpy/konlpy/master/scripts/mecab.sh | bash -s
+
+# cleanse
+RUN apt-get clean && \
+	rm -rf /var/lib/apt/lists/*
 
 # entry
 ENTRYPOINT ["python3"]


### PR DESCRIPTION
`apt-get update` run two times at 'init' phase and 'install konlpy' phase.
Between those two, there was 'cleanse' phase to clean up `apt-get update`-ed cache.
So reordering would be speed up the docker build process.